### PR TITLE
feat(commands): add 'todo' to toggle command options

### DIFF
--- a/lua/specto/commands.lua
+++ b/lua/specto/commands.lua
@@ -20,7 +20,7 @@ local options = {
   complete = function(_, cmd_line)
     local store = {
       [""] = { "toggle" },
-      toggle = { "only", "skip" },
+      toggle = { "only", "skip", "todo" },
     }
     local has_space = string.match(cmd_line, "%s$")
     local params = vim.split(cmd_line, "%s+", { trimempty = true })


### PR DESCRIPTION
Add 'todo' as a valid subcommand option for the toggle command completion.