### PR TITLE
feat: introduce navigation between active feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ toggles. It provides framework-specific controls to mark tests as "only",
   - Works with `context`, `describe`, `example`, `scenario`, `specify`, and
     `test` blocks
 
+- Navigation between active feature flags
+
+  - Jump to next/previous active flag (e.g. `it.only`, `describe.skip`)
+  - Circular navigation (wraps around buffer)
+
 - Smart detection of common test files (e.g. `*.spec.js`, `*_spec.rb`, etc.)
 - Dot-repeat previous actions
 
@@ -75,7 +80,7 @@ Install the plugin with your preferred package manager:
 }
 ```
 
-### Configuration
+## Configuration
 
 Specto comes with the following defaults:
 
@@ -128,6 +133,8 @@ javascript = { -- example: "ruby", etc.
 :Specto toggle skip
 :Specto toggle only
 :Specto toggle todo
+:Specto jump next
+:Specto jump prev
 ```
 
 > [!NOTE]
@@ -139,9 +146,14 @@ The provided commands can either be called directly via `:Specto toggle *` withi
 a test block or used via keybinding.
 
 ```lua
+-- Toggle bindings
 vim.keymap.set("n", "<leader>to", "<cmd>Specto toggle only<CR>", { desc = "Toggle test only" })
 vim.keymap.set("n", "<leader>ts", "<cmd>Specto toggle skip<CR>", { desc = "Toggle test skip" })
 vim.keymap.set("n", "<leader>tt", "<cmd>Specto toggle todo<CR>", { desc = "Toggle test todo" })
+
+-- Navigation bindings
+vim.keymap.set("n", "]t", "<cmd>Specto jump next<CR>", { desc = "Go to next toggle" })
+vim.keymap.set("n", "[t", "<cmd>Specto jump prev<CR>", { desc = "Go to previous toggle" })
 ```
 
 ## Contributing

--- a/doc/specto.nvim.txt
+++ b/doc/specto.nvim.txt
@@ -1,4 +1,4 @@
-*specto.nvim.txt*        For Neovim >= 0.9.0        Last change: 2025 March 02
+*specto.nvim.txt*        For Neovim >= 0.9.0        Last change: 2025 April 10
 
 ==============================================================================
 Table of Contents                              *specto.nvim-table-of-contents*
@@ -6,6 +6,7 @@ Table of Contents                              *specto.nvim-table-of-contents*
   - Features                                            |specto.nvim-features|
   - Getting Started                              |specto.nvim-getting-started|
   - Configuration                                  |specto.nvim-configuration|
+  - Contributing                                    |specto.nvim-contributing|
 
 
 FEATURES                                                *specto.nvim-features*
@@ -17,7 +18,11 @@ FEATURES                                                *specto.nvim-features*
     - Works with `describe()` and `test()` blocks too
 - Support for Ruby RSpec files
     - Toggle skip prefix: `it()` ⟷ `xit()`
-    - Works with `context`, `describe`, `example`, `scenario`, `specify`, and `test` blocks
+    - Works with `context`, `describe`, `example`, `scenario`, `specify`, and
+        `test` blocks
+- Navigation between active feature flags
+    - Jump to next/previous active flag (e.g. `it.only`, `describe.skip`)
+    - Circular navigation (wraps around buffer)
 - Smart detection of common test files (e.g.� `*.spec.js`, `*_spec.rb`, etc.)
 - Dot-repeat previous actions
 
@@ -51,38 +56,17 @@ INSTALLATION ~
 
 Install the plugin with your preferred package manager:
 
-lazy.nvim ~
-
 >lua
+    -- lazy.nvim
     {
       "cange/specto.nvim",
       dependencies = "nvim-treesitter/nvim-treesitter",
-      opts = {}
+      ---@type specto.Config
+      opts = {
+        -- your configuration comes here or leave it empty to use the default settings
+        -- refer to the configuration section below
+      }
     }
-<
-
-
-COMMANDS ~
-
->lua
-    :Specto toggle skip
-    :Specto toggle only
-    :Specto toggle todo
-<
-
-
-  [!NOTE] The feature set depends on the respective language and its testing
-  framework.
-
-KEYBINDINGS ~
-
-The provided commands can either be called directly via `:Specto toggle *`
-within a test block or used via keybinding.
-
->lua
-    vim.keymap.set("n", "<leader>to", "<cmd>Specto toggle only<CR>", { desc = "Toggle test only" })
-    vim.keymap.set("n", "<leader>ts", "<cmd>Specto toggle skip<CR>", { desc = "Toggle test skip" })
-    vim.keymap.set("n", "<leader>tt", "<cmd>Specto toggle todo<CR>", { desc = "Toggle test todo" })
 <
 
 
@@ -91,25 +75,23 @@ CONFIGURATION                                      *specto.nvim-configuration*
 Specto comes with the following defaults:
 
 >lua
-    require("specto").setup({ -- BEGIN_DEFAULT_OPTS
+    ---@type specto.Config
+    {
+      ---@type specto.Exclude
       exclude = {
         filetypes = { -- exclude certain files by default
           "help",
         }
       },
+      ---@type specto.Languages
       languages = {
         -- set default config for all defined languages
-        ["*"] = {
-          filetypes = {},
-          file_patterns = {},
-          features = {},
-        },
-        -- ... other languages
       }
     })
 <
 
-See config.lua <./lua/specto/config.lua> for more details.
+See also config.lua <./lua/specto/config.lua> and types.lua
+<./lua/specto/types.lua> declaration.
 
 
 LANGUAGE SETTINGS ~
@@ -127,14 +109,51 @@ Each language can define an individual set for `only` and `skip` features.
       features = {
         -- subset of criteria of each feature
         only = { -- or skip, todo
-          flag = "only", -- identfier name
-          keywords = { "it", "describe", "test" }, -- defines on which blocks it can be attached to
-          prefix = false, -- position of flag, false adds flag at the end of a keyword
-          separator = ".", -- defines if a flag came with a certain mark eg. `describe.only`
+          flag = "only", -- Defines the actual flag name to be toggled
+          keywords = { "it", "describe", "test" }, -- Defines on which blocks it can be attached to
+          prefix = false, -- Defines position of flag, false adds flag at the end of a keyword
+          separator = ".", -- Defines the separator between keyword and flag
         },
       },
     }
 <
+
+
+COMMANDS ~
+
+>lua
+    :Specto toggle skip
+    :Specto toggle only
+    :Specto toggle todo
+    :Specto jump next
+    :Specto jump prev
+<
+
+
+  [!NOTE] The feature set depends on the respective language and its testing
+  framework.
+
+KEYBINDINGS ~
+
+The provided commands can either be called directly via `:Specto toggle *`
+within a test block or used via keybinding.
+
+>lua
+    -- Toggle bindings
+    vim.keymap.set("n", "<leader>to", "<cmd>Specto toggle only<CR>", { desc = "Toggle test only" })
+    vim.keymap.set("n", "<leader>ts", "<cmd>Specto toggle skip<CR>", { desc = "Toggle test skip" })
+    vim.keymap.set("n", "<leader>tt", "<cmd>Specto toggle todo<CR>", { desc = "Toggle test todo" })
+    
+    -- Navigation bindings
+    vim.keymap.set("n", "]t", "<cmd>Specto jump next<CR>", { desc = "Go to next toggle" })
+    vim.keymap.set("n", "[t", "<cmd>Specto jump prev<CR>", { desc = "Go to previous toggle" })
+<
+
+
+CONTRIBUTING                                        *specto.nvim-contributing*
+
+All contributions are welcome! Just open a pull request. Please read
+CONTRIBUTING.md <./CONTRIBUTING.md>.
 
 Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
 

--- a/lua/specto/commands.lua
+++ b/lua/specto/commands.lua
@@ -13,7 +13,9 @@ local function command(opts)
   local ok, context = pcall(require, "specto." .. context_name)
   if not action_name then
     if context_name == "toggle" then action_name = "only" end
+    if context_name == "jump" then action_name = "next" end
   end
+
   if ok then context[action_name]() end
 end
 
@@ -21,7 +23,8 @@ local options = {
   nargs = "?",
   complete = function(_, cmd_line)
     local store = {
-      [""] = { "toggle" },
+      [""] = { "toggle", "jump" },
+      jump = { "next", "prev" },
       toggle = { "only", "skip", "todo" },
     }
     local has_space = string.match(cmd_line, "%s$")

--- a/lua/specto/jump.lua
+++ b/lua/specto/jump.lua
@@ -1,0 +1,140 @@
+local Util = require("specto.util")
+local Config = require("specto.config")
+local Tree = require("specto.tree")
+local api = vim.api
+
+---@class specto.Jumper
+local M = {}
+
+local Jump = {}
+Jump.__index = Jump
+
+-- Handle compatibility between Lua 5.1 and newer versions
+local unpack = table.unpack or unpack
+
+---@return specto.Jumper
+function Jump:new() return setmetatable({}, self) end
+
+---Find all active feature flag nodes in the current buffer
+---@return TSNode[]
+function Jump:find_active_flags()
+  local config = Config.filetype_config
+  if not config then return {} end
+
+  local nodes = {}
+  local seen = {} -- Track seen nodes to avoid duplicates
+
+  -- Pre-create trees for all feature types
+  local trees = {}
+  for feature_type, _ in pairs(config.features) do
+    trees[feature_type] = Tree:new(feature_type, config)
+  end
+
+  local ok, root = pcall(function() return vim.treesitter.get_node():tree():root() end)
+  if not ok then
+    Util.warn("TreeSitter not available")
+    return {}
+  end
+
+  local queue = { root }
+
+  while #queue > 0 do
+    local node = table.remove(queue, 1)
+    local id = tostring(node:id())
+
+    if not seen[id] then
+      seen[id] = true
+
+      if node:child_count() > 0 then
+        for i = 0, node:child_count() - 1 do
+          table.insert(queue, node:child(i))
+        end
+      end
+
+      -- Check node against all trees
+      for _, tree in pairs(trees) do
+        local matched = tree:next(node, true)
+        if matched and tree:is_active_flag(matched) then
+          table.insert(nodes, matched)
+          break -- Found a match, no need to check other trees
+        end
+      end
+    end
+  end
+
+  -- Sort nodes by position
+  if #nodes > 0 then
+    table.sort(nodes, function(a, b)
+      local a_start_row, a_start_col = a:range()
+      local b_start_row, b_start_col = b:range()
+      return a_start_row < b_start_row or (a_start_row == b_start_row and a_start_col < b_start_col)
+    end)
+  end
+
+  return nodes
+end
+
+---Find next/prev node from current position
+---@param nodes TSNode[]
+---@param type specto.JumpType
+---@return TSNode|nil
+function Jump:find_target_node(nodes, type)
+  if #nodes == 0 then return nil end
+
+  local cursor_row, cursor_col = unpack(api.nvim_win_get_cursor(0))
+  cursor_row = cursor_row - 1 -- Convert to 0-based index
+
+  if type == "next" then
+    for _, node in ipairs(nodes) do
+      local start_row, start_col = node:range()
+      if start_row > cursor_row or (start_row == cursor_row and start_col > cursor_col) then return node end
+    end
+    return nodes[1] -- Wrap to first
+  else
+    local prev_node = nil
+    for _, node in ipairs(nodes) do
+      local start_row, start_col = node:range()
+      if start_row < cursor_row or (start_row == cursor_row and start_col < cursor_col) then
+        prev_node = node
+      else
+        break -- We've gone past current position
+      end
+    end
+    return prev_node or nodes[#nodes] -- Return last found node or wrap to last
+  end
+end
+
+---@param type specto.JumpType
+function Jump:trigger(type)
+  local config = Config.filetype_config
+  if not config then
+    Util.warn("No configuration found for current filetype")
+    return
+  end
+
+  local active_flags = self:find_active_flags()
+  if #active_flags == 0 then
+    Util.info("No active feature flags found")
+    return
+  end
+
+  local target = self:find_target_node(active_flags, type)
+  if not target then
+    Util.warn("Could not find target node")
+    return
+  end
+  local row, col = target:range()
+  -- Convert from 0-based (TreeSitter) to 1-based (Neovim) line numbers
+  api.nvim_win_set_cursor(0, { row + 1, col })
+end
+
+M._jump = Jump:new()
+
+---@param type specto.JumpType
+function M.jump(type) M._jump:trigger(type) end
+
+function M.next() require("specto.repeat").dot_repeat("next") end
+
+function M.prev() require("specto.repeat").dot_repeat("prev") end
+
+return M

--- a/lua/specto/repeat.lua
+++ b/lua/specto/repeat.lua
@@ -18,7 +18,7 @@ end
 function M.jump()
   if M._last_type then
     Util.debug(string.format("repeat:jump %q", M._last_type))
-    require("specto.jump")[M._last_type]()
+    require("specto.jump").jump(M._last_type --[[@as specto.JumpType]])
   end
 end
 

--- a/lua/specto/repeat.lua
+++ b/lua/specto/repeat.lua
@@ -4,7 +4,7 @@
 local Util = require("specto.util")
 ---@class specto.Repeat
 ---@field private _last_type specto.ToggleType | specto.JumpType | nil
-M = {}
+local M = {}
 M._last_type = nil
 
 ---@private

--- a/lua/specto/types.lua
+++ b/lua/specto/types.lua
@@ -26,11 +26,12 @@
 ---@field languages specto.Languages
 
 ---@alias specto.ToggleType '"only"' | '"skip"' | '"todo"'
+---@alias specto.JumpType '"next"' | '"prev"'
 
 ---@class specto.Tree
 ---@field type specto.ToggleType
 ---@field keywords string[]
----@field get_node fun(self: specto.Tree): TSNode | nil
+---@field get_node fun(self: specto.Tree, line?: number): TSNode | nil
 ---@field get_text fun(self: specto.Tree, node: TSNode): string
 ---@field replace_text fun(self: specto.Tree, node: TSNode, content: string, range?: specto.ColumnRange)
 


### PR DESCRIPTION
### What's Changed

Add ability to jump between active feature flags (e.g. `it.only`, `test.skip`, etc) in test files.

Includes:

- Next/previous navigation with wrap-around
- Support for both prefix and suffix feature flags
- Integration with dot-repeat functionality
- New commands: 
  ```lua
  :Specto jump next
  :Specto jump prev
  ```
- Suggested keymaps: `]t` and `[t`
