### PR TITLE
fix(deps)!: update nvim-treesitter to neovim-treesitter

### DIFF
--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -19,7 +19,7 @@ jobs:
         uses: kdheepak/panvimdoc@main
         with:
           description: "A Neovim plugin that allows you to toggle test blocks on/off."
-          version: "NVIM v0.9.0"
+          version: "NVIM v0.10.0"
           vimdoc: ${{ github.event.repository.name }}
       - name: formatting via stylua
         uses: JohnnyMorganz/stylua-action@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ releases are managed.
 
 1. Go to GitHub Releases
 2. Click "Draft a new release"
-3. Create a new tag following [semver](https://semver.org/) (e.g. `v1.0.0`)
+3. Create a new tag following [SemVer](https://semver.org/) (e.g. `v1.0.0`)
+   - updates docs within `doc/` automatically
 4. Click "Generate release notes"
 5. Review and publish

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ describe('context', () => {
 ### Requirements
 
 - Neovim >= 0.9.0
-- [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [nvim-treesitter](https://github.com/neovim-treesitter/nvim-treesitter)
 
 ### Installation
 
@@ -71,7 +71,7 @@ Install the plugin with your preferred package manager:
 -- lazy.nvim
 {
   "cange/specto.nvim",
-  dependencies = "nvim-treesitter/nvim-treesitter",
+  dependencies = "neovim-treesitter/nvim-treesitter",
   ---@type specto.Config
   opts = {
     -- your configuration comes here or leave it empty to use the default settings

--- a/doc/specto.nvim.txt
+++ b/doc/specto.nvim.txt
@@ -49,7 +49,7 @@ GETTING STARTED                                  *specto.nvim-getting-started*
 REQUIREMENTS ~
 
 - Neovim >= 0.9.0
-- nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter>
+- nvim-treesitter <https://github.com/neovim-treesitter/nvim-treesitter>
 
 
 INSTALLATION ~
@@ -60,7 +60,7 @@ Install the plugin with your preferred package manager:
     -- lazy.nvim
     {
       "cange/specto.nvim",
-      dependencies = "nvim-treesitter/nvim-treesitter",
+      dependencies = "neovim-treesitter/nvim-treesitter",
       ---@type specto.Config
       opts = {
         -- your configuration comes here or leave it empty to use the default settings
@@ -101,11 +101,11 @@ Each language can define an individual set for `only` and `skip` features.
 >lua
     javascript = { -- example: "ruby", etc.
       filetypes = { "javascript", "typescript" }, -- a subset of supported language
-    
+
       -- Files or directories where tests can be found.
       -- Expects an array of string patterns that can be used with `string.match`.
       file_patterns = {  }, -- eg. `{ "__tests__/", "%.?spec%." }`
-    
+
       features = {
         -- subset of criteria of each feature
         only = { -- or skip, todo
@@ -143,7 +143,7 @@ within a test block or used via keybinding.
     vim.keymap.set("n", "<leader>to", "<cmd>Specto toggle only<CR>", { desc = "Toggle test only" })
     vim.keymap.set("n", "<leader>ts", "<cmd>Specto toggle skip<CR>", { desc = "Toggle test skip" })
     vim.keymap.set("n", "<leader>tt", "<cmd>Specto toggle todo<CR>", { desc = "Toggle test todo" })
-    
+
     -- Navigation bindings
     vim.keymap.set("n", "]t", "<cmd>Specto jump next<CR>", { desc = "Go to next toggle" })
     vim.keymap.set("n", "[t", "<cmd>Specto jump prev<CR>", { desc = "Go to previous toggle" })


### PR DESCRIPTION
### What's Changed:
neovim-treesitter is the successor project after nvim-treesitter repo
has been archived.

**BREAKING**: neovim-treesitter requires Neovim v0.10.0+